### PR TITLE
Create zip files to make deployment easier for existing installs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,6 +6,33 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  ZIP_BASE_NAME: luacsforbarotrauma
+  ZIP_FILES_SERVER: |
+    DedicatedServer.deps.json
+    DedicatedServer.dll
+    DedicatedServer.pdb
+  ZIP_FILES_CLIENT: |
+    Barotrauma.deps.json
+    Barotrauma.dll
+    Barotrauma.pdb
+  ZIP_FILES_SHARED: |
+    0Harmony.dll
+    MoonSharp.Interpreter.dll
+    MonoMod.Common.dll
+    Mono.Cecil.dll
+    Mono.Cecil.Mdb.dll
+    Mono.Cecil.Pdb.dll
+    Mono.Cecil.Rocks.dll
+    Microsoft.CodeAnalysis.CSharp.Scripting.dll
+    Microsoft.CodeAnalysis.CSharp.dll
+    Microsoft.CodeAnalysis.dll
+    Microsoft.CodeAnalysis.Scripting.dll
+    System.Collections.Immutable.dll
+    System.Reflection.Metadata.dll
+    System.Runtime.CompilerServices.Unsafe.dll
+    Lua
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,26 +65,63 @@ jobs:
       - name: "Build: MacClient"
         run: dotnet publish Barotrauma/BarotraumaClient/MacClient.csproj -c Release -clp:"ErrorsOnly;Summary" --self-contained -r osx-x64 \/p:Platform="x64"
 
-      - name: "Create zip file: windows"
-        uses: thedoctor0/zip-release@main
-        with:
-          type: zip
-          filename: barotrauma_lua_windows.zip
-          directory: Barotrauma/bin/ReleaseWindows/netcoreapp3.1/win-x64/publish
+      - name: Create zip files
+        run: |
+          IFS=$'\n' readarray -td $'\n' ZIP_FILES_SHARED <<< "$ZIP_FILES_SHARED"
+          IFS=$'\n' readarray -td $'\n' ZIP_FILES_CLIENT <<< "$ZIP_FILES_CLIENT"
+          IFS=$'\n' readarray -td $'\n' ZIP_FILES_SERVER <<< "$ZIP_FILES_SERVER"
 
-      - name: "Create zip file: linux"
-        uses: thedoctor0/zip-release@main
-        with:
-          type: zip
-          filename: barotrauma_lua_linux.zip
-          directory: Barotrauma/bin/ReleaseLinux/netcoreapp3.1/linux-x64/publish
+          for i in "${!ZIP_FILES_SHARED[@]}"; do
+            file="${ZIP_FILES_SHARED[i]}"
+            if [[ -z "$file" ]]; then
+              unset "ZIP_FILES_SHARED[$i]"
+            fi
+          done
 
-      - name: "Create zip file: mac"
-        uses: thedoctor0/zip-release@main
-        with:
-          type: zip
-          filename: barotrauma_lua_mac.zip
-          directory: Barotrauma/bin/ReleaseMac/netcoreapp3.1/osx-x64/publish
+          for i in "${!ZIP_FILES_CLIENT[@]}"; do
+            file="${ZIP_FILES_CLIENT[i]}"
+            if [[ -z "$file" ]]; then
+              unset "ZIP_FILES_CLIENT[$i]"
+            fi
+          done
+
+          for i in "${!ZIP_FILES_SERVER[@]}"; do
+            file="${ZIP_FILES_SERVER[i]}"
+            if [[ -z "$file" ]]; then
+              unset "ZIP_FILES_SERVER[$i]"
+            fi
+          done
+
+          platforms=(
+            "windows"
+            "linux"
+            "mac"
+          )
+          publish_dirs=(
+            "Barotrauma/bin/ReleaseWindows/netcoreapp3.1/win-x64/publish"
+            "Barotrauma/bin/ReleaseLinux/netcoreapp3.1/linux-x64/publish"
+            "Barotrauma/bin/ReleaseMac/netcoreapp3.1/osx-x64/publish"
+          )
+
+          for i in "${!platforms[@]}"; do
+            (
+              platform="${platforms[i]}"
+              publish_dir="${publish_dirs[i]}"
+              cd "$publish_dir"
+              echo "Creating build_${platform}.zip"
+              zip -x *.zip -r "${ZIP_BASE_NAME}_build_${platform}.zip" .
+              echo "Creating patch_${platform}_client.zip"
+              zip -x *.zip -r "${ZIP_BASE_NAME}_patch_${platform}_client.zip" \
+                "${ZIP_FILES_SHARED[@]}" \
+                mscordaccore_amd64_amd64_* \
+                "${ZIP_FILES_CLIENT[@]}"
+              echo "Creating patch_${platform}_server.zip"
+              zip -x *.zip -r "${ZIP_BASE_NAME}_patch_${platform}_server.zip" \
+                "${ZIP_FILES_SHARED[@]}" \
+                mscordaccore_amd64_amd64_* \
+                "${ZIP_FILES_SERVER[@]}"
+            )
+          done
 
       - name: Publish release
         uses: marvinpinto/action-automatic-releases@v1.2.1
@@ -67,6 +131,12 @@ jobs:
           prerelease: false
           title: Automatic Build
           files: |
-            Barotrauma/bin/ReleaseWindows/netcoreapp3.1/win-x64/publish/barotrauma_lua_windows.zip
-            Barotrauma/bin/ReleaseLinux/netcoreapp3.1/linux-x64/publish/barotrauma_lua_linux.zip
-            Barotrauma/bin/ReleaseMac/netcoreapp3.1/osx-x64/publish/barotrauma_lua_mac.zip
+            Barotrauma/bin/ReleaseWindows/netcoreapp3.1/win-x64/publish/${{ env.ZIP_BASE_NAME }}_build_windows.zip
+            Barotrauma/bin/ReleaseWindows/netcoreapp3.1/win-x64/publish/${{ env.ZIP_BASE_NAME }}_patch_windows_client.zip
+            Barotrauma/bin/ReleaseWindows/netcoreapp3.1/win-x64/publish/${{ env.ZIP_BASE_NAME }}_patch_windows_server.zip
+            Barotrauma/bin/ReleaseLinux/netcoreapp3.1/linux-x64/publish/${{ env.ZIP_BASE_NAME }}_build_linux.zip
+            Barotrauma/bin/ReleaseLinux/netcoreapp3.1/linux-x64/publish/${{ env.ZIP_BASE_NAME }}_patch_linux_client.zip
+            Barotrauma/bin/ReleaseLinux/netcoreapp3.1/linux-x64/publish/${{ env.ZIP_BASE_NAME }}_patch_linux_server.zip
+            Barotrauma/bin/ReleaseMac/netcoreapp3.1/osx-x64/publish/${{ env.ZIP_BASE_NAME }}_build_mac.zip
+            Barotrauma/bin/ReleaseMac/netcoreapp3.1/osx-x64/publish/${{ env.ZIP_BASE_NAME }}_patch_mac_client.zip
+            Barotrauma/bin/ReleaseMac/netcoreapp3.1/osx-x64/publish/${{ env.ZIP_BASE_NAME }}_patch_mac_server.zip

--- a/luacs-docs/lua/css/ldoc.css
+++ b/luacs-docs/lua/css/ldoc.css
@@ -364,14 +364,26 @@ article p {
   line-height: calc(var(--font-normal) + 4px);
 }
 
-article p + p,
-article h2 + p,
-article pre + p {
+article ul,
+article ol {
+  padding-left: 2em;
+}
+
+article li + li {
+  margin-top: 0.25em;
+}
+
+article p + *,
+article pre + *,
+article ol + *,
+article ul + *,
+article iframe + *,
+article h2 + * {
   margin-top: var(--padding-small);
 }
 
-article h3 + p,
-article h4 + p {
+article h3 + *,
+article h4 + * {
   margin-top: var(--padding-tiny);
 }
 

--- a/luacs-docs/lua/manual/installing-lua-for-barotrauma-manually.md
+++ b/luacs-docs/lua/manual/installing-lua-for-barotrauma-manually.md
@@ -1,89 +1,39 @@
 # Installing Lua For Barotrauma Manually
 
-## Notice: Using the LuaForBarotrauma package is not required if it's installed manually, but you may use it anyway if you wish to support the mod, since players automatically download packages when joining the server.
+**Notice**: the "Lua For Barotrauma" content package is not required if installed manually, but you may use it anyway if you wish to support the mod, since players automatically download packages when joining the server.
 
-## If you are getting TextManager errors, open config_player.xml in your server and change the language from None to English
+If you get TextManager errors, open `config_player.xml` in your server folder and change the language from "None" to "English"
 
-## Adding Lua For Barotrauma to an existing server
-1 - Download [latest version of LuaForBarotrauma](https://github.com/evilfactory/Barotrauma-lua-attempt/releases/tag/latest), choose the correct platform in the assets drop down.<br>
-2 - Extract the zip file<br>
-3 - Copy the following files inside the extracted zip:<br>
+## Adding to an existing server
 
-- **DedicatedServer.deps.json**
-- **DedicatedServer.dll**
-- **DedicatedServer.pdb**
-- **0Harmony.dll**
-- **Sigil.dll**
-- **MoonSharp.Interpreter.dll**
-- **MonoMod.Common.dll**
-- **Mono.Cecil.dll**
-- **Mono.Cecil.Mdb.dll**
-- **Mono.Cecil.Pdb.dll**
-- **Mono.Cecil.Rocks.dll**
-- **Microsoft.CodeAnalysis.CSharp.Scripting.dll**
-- **Microsoft.CodeAnalysis.CSharp.dll**
-- **Microsoft.CodeAnalysis.dll**
-- **Microsoft.CodeAnalysis.Scripting.dll**
-- **System.Collections.Immutable.dll**
-- **System.Reflection.Metadata.dll**
-- **System.Runtime.CompilerServices.Unsafe.dll**
-- file that starts with **mscordaccore\_amd64\_amd64\_**
-- and the **Lua/** folder
+1. Download [the latest server patch](https://github.com/evilfactory/LuaCsForBarotrauma/releases/tag/latest) (make sure to download the "patch" zip for your platform, e.g. `luacsforbarotrauma_patch_windows_server.zip`)
 
-4 - Paste them to your existing server, and let it replace the files<br>
+2. Extract the zip archive into your existing server folder and replace files as necessary
 
-## Adding Lua For Barotrauma to an existing client
+## Adding to an existing client
 
-Same as above, but instead you need to copy/replace the following files:
+1. Download [the latest client patch](https://github.com/evilfactory/LuaCsForBarotrauma/releases/tag/latest) (make sure to download the "patch" zip for your platform, e.g. `luacsforbarotrauma_patch_windows_client.zip`)
 
-- **Barotrauma.deps.json**
-- **Barotrauma.dll**
-- **Barotrauma.pdb**
-- **0Harmony.dll**
-- **Sigil.dll**
-- **MoonSharp.Interpreter.dll**
-- **MonoMod.Common.dll**
-- **Mono.Cecil.dll**
-- **Mono.Cecil.Mdb.dll**
-- **Mono.Cecil.Pdb.dll**
-- **Mono.Cecil.Rocks.dll**
-- **Microsoft.CodeAnalysis.CSharp.Scripting.dll**
-- **Microsoft.CodeAnalysis.CSharp.dll**
-- **Microsoft.CodeAnalysis.dll**
-- **Microsoft.CodeAnalysis.Scripting.dll**
-- **System.Collections.Immutable.dll**
-- **System.Reflection.Metadata.dll**
-- **System.Runtime.CompilerServices.Unsafe.dll**
-- file that starts with **mscordaccore\_amd64\_amd64\_**
-- and the **Lua/** folder
+2. Extract the zip archive into your game folder and replace files as necessary
 
-
-## Using Lua For Barotrauma from scratch
+## Installing from scratch
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ov0MUOUVB7A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-1 - Download [latest version of LuaForBarotrauma](https://github.com/evilfactory/Barotrauma-lua-attempt/releases/tag/latest), choose the correct platform in the assets drop down.<br>
-
-2 - Extract the zip file<br>
-
-3 - Find the Content folder in your original Barotrauma game: <br>
-
- ![](https://cdn.discordapp.com/attachments/799752463619325968/833120013149929492/unknown.png)
- ![](https://cdn.discordapp.com/attachments/799752463619325968/833120379378991104/unknown.png)
- ![](https://cdn.discordapp.com/attachments/799752463619325968/833120841277374464/unknown.png)
-
-4 - Copy the Content folder to the extracted folder <br>
-
-![](https://cdn.discordapp.com/attachments/799752463619325968/833133217300742154/unknown.png)
-
-6 - Optional: Copy config_player.xml from your original game so it retains your configurations.
-
-7 - Done! Now run DedicatedServer.exe to run the modded server or run Barotrauma.exe to run the modded client.<br>
+1. Download [the latest build](https://github.com/evilfactory/LuaCsForBarotrauma/releases/tag/latest) (make sure to download the "build" zip for your platform, e.g `luacsforbarotrauma_build_windows.zip`)
+2. Extract the zip file
+3. Find the Content folder in your original Barotrauma game:<br/>
+  <img src="https://cdn.discordapp.com/attachments/799752463619325968/833120013149929492/unknown.png" width="500" /><br/>
+  <img src="https://cdn.discordapp.com/attachments/799752463619325968/833120379378991104/unknown.png" width="500" /><br/>
+  <img src="https://cdn.discordapp.com/attachments/799752463619325968/833120841277374464/unknown.png" width="500" />
+4. Copy the Content folder to the extracted folder:<br/>
+  <img src="https://cdn.discordapp.com/attachments/799752463619325968/833133217300742154/unknown.png" width="500" />
+6. **Optional**: Copy `config_player.xml` from your original game so it retains your configurations
+7. Done! Now run DedicatedServer.exe to run the modded server or run Barotrauma.exe to run the modded client
 
 ### Linux notice
-Sometimes you will get steam initialization errors, most of the time it's because it's missing the linux64/steamclient.so binary, so you can just copy the binary from your steam instalation over to the folder and it should work.
 
-
+Sometimes you will get steam initialization errors, most of the time it's because it's missing the `linux64/steamclient.so` binary, so you can just copy the binary from your steam installation over to the folder and it should work.
 
 ## Checking if everything is working
 

--- a/luacs-docs/lua/scripts/build.ps1
+++ b/luacs-docs/lua/scripts/build.ps1
@@ -9,7 +9,7 @@ try {
   Copy-Item -Path ./js/. -Destination ./build -Recurse -Force | Out-Null
 
   if ((Get-Command "lua_modules/bin/ldoc" -ErrorAction SilentlyContinue) -eq $null) {
-    echo "ldoc not found; please run docs/scripts/install.ps1"
+    echo "ldoc not found; please run scripts/install.ps1"
     exit 1
   }
 

--- a/luacs-docs/lua/scripts/build.sh
+++ b/luacs-docs/lua/scripts/build.sh
@@ -6,7 +6,7 @@ cd "$DIR/.."
 ldoc_path=./lua_modules/bin/ldoc
 
 if [[ ! -x "$ldoc_path" ]]; then
-  echo "ldoc not found; please run docs/scripts/install.sh"
+  echo "ldoc not found; please run scripts/install.sh"
   exit 1
 fi
 


### PR DESCRIPTION
This changes the `publish-release` workflow to create "patch" zip files that contain only the required files needed to update a manual install, e.g:
![image](https://user-images.githubusercontent.com/920910/184274140-b2696eac-5faa-4002-94b5-3acb25d06670.png)
