### PR TITLE
Support for Reflection Lookup of Mod Types

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
@@ -170,8 +170,8 @@ namespace Barotrauma
 
 			var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
 				.WithMetadataImportOptions(MetadataImportOptions.All)
-				.WithOptimizationLevel(OptimizationLevel.Release)
-				.WithAllowUnsafe(true); //Allow the use of "IgnoreAccessChecksToAttribute" from Compiler Services
+                .WithOptimizationLevel(OptimizationLevel.Release)
+				.WithAllowUnsafe(true); 
 			var compilation = CSharpCompilation.Create(CsScriptAssembly, syntaxTrees, defaultReferences, options);
 
 			using (var mem = new MemoryStream())

--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
@@ -213,13 +213,17 @@ namespace Barotrauma
 		}
 
         /// <summary>
-        /// This function should be used whenever a new assembly is created. Wrapper to allow more complicated setup.
+        /// This function should be used whenever a new assembly is created. Wrapper to allow more complicated setup later if need be.
         /// </summary>
         private static void RegisterAssemblyWithNativeGame(Assembly assembly)
         {
             Barotrauma.ReflectionUtils.AddNonAbstractAssemblyTypes(assembly);
         }
 
+        /// <summary>
+        /// This function should be used whenever a new assembly is about to be destroyed/unloaded. Wrapper to allow more complicated setup later if need be.
+        /// </summary>
+        /// <param name="assembly">Assembly to remove</param>
         private static void UnregisterAssemblyFromNativeGame(Assembly assembly)
         {
             Barotrauma.ReflectionUtils.RemoveAssemblyFromCache(assembly);

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
@@ -28,6 +28,11 @@ namespace Barotrauma
             return types;
         }
 
+        /// <summary>
+        /// Adds an assembly's Non-Abstract Types to the cache for Barotrauma's Type lookup. 
+        /// </summary>
+        /// <param name="assembly">Assembly to be added</param>
+        /// <param name="overwrite">Whether or not to overwrite an entry if the assembly already exists within it.</param>
         public static void AddNonAbstractAssemblyTypes(Assembly assembly, bool overwrite = false)
         {
             if (cachedNonAbstractTypes.ContainsKey(assembly))
@@ -52,6 +57,10 @@ namespace Barotrauma
             }
         }
 
+        /// <summary>
+        /// Removes an assembly from the cache for Barotrauma's Type lookup.
+        /// </summary>
+        /// <param name="assembly">Assembly to remove.</param>
         public static void RemoveAssemblyFromCache(Assembly assembly) => cachedNonAbstractTypes.Remove(assembly);
 
         public static Option<TBase> ParseDerived<TBase, TInput>(TInput input) where TInput : notnull

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
@@ -19,6 +19,8 @@ namespace Barotrauma
             if (!cachedNonAbstractTypes.ContainsKey(assembly))
                 AddNonAbstractAssemblyTypes(assembly);
 
+            #warning TODO: Add safety checks in case an assembly is unloaded without being removed from the cache.
+            
             List<Type> types = new List<Type>();
             foreach (var typearr in cachedNonAbstractTypes)
                 types = types.Concat(typearr.Value.Where(t => t.IsSubclassOf(typeof(T)))).ToList();


### PR DESCRIPTION
Adds support and automatic management for mod class types to be added to the native Barotrauma Reflection Type lookup. This allows mods to create completely new Item & ItemComponent subtypes and implement completely new types of functionality into the base game. 