### PR TITLE
Support for Reflection Lookup of Mod Types

### DIFF
--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
@@ -52,12 +52,12 @@ namespace Barotrauma
 				{
 					if (rtValue == RunType.Standard && isEnabled)
 					{
-						LuaCsSetup.PrintCsMessage($"Standard run C# of {cp.Name}");
+						LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Standard)");
 						return true;
 					}
 					else if (rtValue == RunType.Forced)
 					{
-						LuaCsSetup.PrintCsMessage($"Forced run C# of {cp.Name}");
+						LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Forced)");
 						return true;
 					}
 					else if (rtValue == RunType.None)
@@ -71,7 +71,7 @@ namespace Barotrauma
 
 			if (isEnabled)
 			{
-				LuaCsSetup.PrintCsMessage($"Assumed run C# of {cp.Name}");
+				LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Assumed)");
 				return true;
 			}
 			else
@@ -82,9 +82,11 @@ namespace Barotrauma
 
 		public void SearchFolders()
 		{
+            var packagesAdded = new HashSet<ContentPackage>();
 			var paths = new Dictionary<string, string>();
 			foreach (var cp in ContentPackageManager.AllPackages.Concat(ContentPackageManager.EnabledPackages.All))
 			{
+                if (packagesAdded.Contains(cp)) { continue; }
 				var path = $"{Path.GetFullPath(Path.GetDirectoryName(cp.Path)).Replace('\\', '/')}/";
 				if (ShouldRun(cp, path))
 				{
@@ -99,6 +101,7 @@ namespace Barotrauma
 					{
 						paths.Add(cp.Name, path);
 					}
+                    packagesAdded.Add(cp);
 				}
 			}
 

--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
@@ -14,190 +14,190 @@ using System.Xml.Linq;
 
 namespace Barotrauma
 {
-	class CsScriptLoader : CsScriptBase
-	{
-		private List<MetadataReference> defaultReferences;
+    class CsScriptLoader : CsScriptBase
+    {
+        private List<MetadataReference> defaultReferences;
 
-		private Dictionary<string, List<string>> sources;
-		public Assembly Assembly { get; private set; }
+        private Dictionary<string, List<string>> sources;
+        public Assembly Assembly { get; private set; }
 
-		public CsScriptLoader()
-		{
-			defaultReferences = AppDomain.CurrentDomain.GetAssemblies()
-				.Where(a => !(a.IsDynamic || string.IsNullOrEmpty(a.Location) || a.Location.Contains("xunit")))
-				.Select(a => MetadataReference.CreateFromFile(a.Location) as MetadataReference)
-				.ToList();
+        public CsScriptLoader()
+        {
+            defaultReferences = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => !(a.IsDynamic || string.IsNullOrEmpty(a.Location) || a.Location.Contains("xunit")))
+                .Select(a => MetadataReference.CreateFromFile(a.Location) as MetadataReference)
+                .ToList();
 
-			sources = new Dictionary<string, List<string>>();
+            sources = new Dictionary<string, List<string>>();
             Assembly = null;
         }
 
-		private enum RunType { Standard, Forced, None };
-		private bool ShouldRun(ContentPackage cp, string path)
-		{
-			if (!Directory.Exists(path + "CSharp"))
-			{
-				return false;
-			}
-
-			var isEnabled = ContentPackageManager.EnabledPackages.All.Contains(cp);
-			if (File.Exists(path + "CSharp/RunConfig.xml"))
-			{
-				Stream stream = File.Open(path + "CSharp/RunConfig.xml", FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-				var doc = XDocument.Load(stream);
-				var elems = doc.Root.Elements().ToArray();
-				var elem = elems.FirstOrDefault(e => e.Name.LocalName.Equals(LuaCsSetup.IsServer ? "Server" : (LuaCsSetup.IsClient ? "Client" : "None"), StringComparison.OrdinalIgnoreCase));
-
-				if (elem != null && Enum.TryParse(elem.Value, true, out RunType rtValue))
-				{
-					if (rtValue == RunType.Standard && isEnabled)
-					{
-						LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Standard)");
-						return true;
-					}
-					else if (rtValue == RunType.Forced)
-					{
-						LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Forced)");
-						return true;
-					}
-					else if (rtValue == RunType.None)
-					{
-						return false;
-					}
-				}
-
-				stream.Close();
-			}
-
-			if (isEnabled)
-			{
-				LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Assumed)");
-				return true;
-			}
-			else
-			{
-				return false;
-			}
-		}
-
-		public void SearchFolders()
-		{
-            var packagesAdded = new HashSet<ContentPackage>();
-			var paths = new Dictionary<string, string>();
-			foreach (var cp in ContentPackageManager.AllPackages.Concat(ContentPackageManager.EnabledPackages.All))
-			{
-                if (packagesAdded.Contains(cp)) { continue; }
-				var path = $"{Path.GetFullPath(Path.GetDirectoryName(cp.Path)).Replace('\\', '/')}/";
-				if (ShouldRun(cp, path))
-				{
-					if (paths.ContainsKey(cp.Name))
-					{
-						if (ContentPackageManager.EnabledPackages.All.Contains(cp))
-						{
-							paths[cp.Name] = path;
-						}
-					}
-					else
-					{
-						paths.Add(cp.Name, path);
-					}
-                    packagesAdded.Add(cp);
-				}
-			}
-
-			foreach ((var _, var path) in paths)
-			{
-				RunFolder(path);
-			}
-		}
-
-		public bool HasSources { get => sources.Count > 0; }
-
-		private void AddSources(string folder)
+        private enum RunType { Standard, Forced, None };
+        private bool ShouldRun(ContentPackage cp, string path)
         {
-			foreach (var str in DirSearch(folder))
-			{
-				string s = str.Replace("\\", "/");
+            if (!Directory.Exists(path + "CSharp"))
+            {
+                return false;
+            }
 
-				if (sources.ContainsKey(folder))
-				{
-					sources[folder].Add(s);
-				}
-				else
-				{
-					sources.Add(folder, new List<string> { s });
-				}
-			}
-		}
+            var isEnabled = ContentPackageManager.EnabledPackages.All.Contains(cp);
+            if (File.Exists(path + "CSharp/RunConfig.xml"))
+            {
+                Stream stream = File.Open(path + "CSharp/RunConfig.xml", FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                var doc = XDocument.Load(stream);
+                var elems = doc.Root.Elements().ToArray();
+                var elem = elems.FirstOrDefault(e => e.Name.LocalName.Equals(LuaCsSetup.IsServer ? "Server" : (LuaCsSetup.IsClient ? "Client" : "None"), StringComparison.OrdinalIgnoreCase));
 
-		private void RunFolder(string folder)
-		{
+                if (elem != null && Enum.TryParse(elem.Value, true, out RunType rtValue))
+                {
+                    if (rtValue == RunType.Standard && isEnabled)
+                    {
+                        LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Standard)");
+                        return true;
+                    }
+                    else if (rtValue == RunType.Forced)
+                    {
+                        LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Forced)");
+                        return true;
+                    }
+                    else if (rtValue == RunType.None)
+                    {
+                        return false;
+                    }
+                }
 
-			AddSources(folder + "/CSharp/Shared");
+                stream.Close();
+            }
+
+            if (isEnabled)
+            {
+                LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Assumed)");
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public void SearchFolders()
+        {
+            var packagesAdded = new HashSet<ContentPackage>();
+            var paths = new Dictionary<string, string>();
+            foreach (var cp in ContentPackageManager.AllPackages.Concat(ContentPackageManager.EnabledPackages.All))
+            {
+                if (packagesAdded.Contains(cp)) { continue; }
+                var path = $"{Path.GetFullPath(Path.GetDirectoryName(cp.Path)).Replace('\\', '/')}/";
+                if (ShouldRun(cp, path))
+                {
+                    if (paths.ContainsKey(cp.Name))
+                    {
+                        if (ContentPackageManager.EnabledPackages.All.Contains(cp))
+                        {
+                            paths[cp.Name] = path;
+                        }
+                    }
+                    else
+                    {
+                        paths.Add(cp.Name, path);
+                    }
+                    packagesAdded.Add(cp);
+                }
+            }
+
+            foreach ((var _, var path) in paths)
+            {
+                RunFolder(path);
+            }
+        }
+
+        public bool HasSources { get => sources.Count > 0; }
+
+        private void AddSources(string folder)
+        {
+            foreach (var str in DirSearch(folder))
+            {
+                string s = str.Replace("\\", "/");
+
+                if (sources.ContainsKey(folder))
+                {
+                    sources[folder].Add(s);
+                }
+                else
+                {
+                    sources.Add(folder, new List<string> { s });
+                }
+            }
+        }
+
+        private void RunFolder(string folder)
+        {
+
+            AddSources(folder + "/CSharp/Shared");
 
 #if SERVER
-			AddSources(folder + "/CSharp/Server");
+            AddSources(folder + "/CSharp/Server");
 #else
-			AddSources(folder + "/CSharp/Client");
+            AddSources(folder + "/CSharp/Client");
 #endif
-		}
+        }
 
-		private IEnumerable<SyntaxTree> ParseSources() {
-			var syntaxTrees = new List<SyntaxTree>();
+        private IEnumerable<SyntaxTree> ParseSources() {
+            var syntaxTrees = new List<SyntaxTree>();
 
-			if (sources.Count <= 0) throw new Exception("No Cs sources detected");
-			syntaxTrees.Add(AssemblyInfoSyntaxTree(CsScriptAssembly));
-			foreach ((var folder, var src) in sources)
+            if (sources.Count <= 0) throw new Exception("No Cs sources detected");
+            syntaxTrees.Add(AssemblyInfoSyntaxTree(CsScriptAssembly));
+            foreach ((var folder, var src) in sources)
             {
-				try
-				{
-					foreach (var file in src)
-					{
-						var tree = SyntaxFactory.ParseSyntaxTree(File.ReadAllText(file), ParseOptions, file);
+                try
+                {
+                    foreach (var file in src)
+                    {
+                        var tree = SyntaxFactory.ParseSyntaxTree(File.ReadAllText(file), ParseOptions, file);
 
-						syntaxTrees.Add(tree);
-					}
-				}
-				catch (Exception ex)
-				{
-					LuaCsSetup.PrintCsError("Error loading '" + folder + "':\n" + ex.Message + "\n" + ex.StackTrace);
-				}
-			}
+                        syntaxTrees.Add(tree);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    LuaCsSetup.PrintCsError("Error loading '" + folder + "':\n" + ex.Message + "\n" + ex.StackTrace);
+                }
+            }
 
-			return syntaxTrees;
-		}
+            return syntaxTrees;
+        }
 
-		public List<Type> Compile() 
-		{
-			IEnumerable<SyntaxTree> syntaxTrees = ParseSources();
+        public List<Type> Compile() 
+        {
+            IEnumerable<SyntaxTree> syntaxTrees = ParseSources();
 
-			var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-				.WithMetadataImportOptions(MetadataImportOptions.All)
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithMetadataImportOptions(MetadataImportOptions.All)
                 .WithOptimizationLevel(OptimizationLevel.Release)
-				.WithAllowUnsafe(true); 
-			var compilation = CSharpCompilation.Create(CsScriptAssembly, syntaxTrees, defaultReferences, options);
+                .WithAllowUnsafe(true); 
+            var compilation = CSharpCompilation.Create(CsScriptAssembly, syntaxTrees, defaultReferences, options);
 
-			using (var mem = new MemoryStream())
-			{
-				var result = compilation.Emit(mem);
-				if (!result.Success)
-				{
-					IEnumerable<Diagnostic> failures = result.Diagnostics.Where(d => d.IsWarningAsError || d.Severity == DiagnosticSeverity.Error);
+            using (var mem = new MemoryStream())
+            {
+                var result = compilation.Emit(mem);
+                if (!result.Success)
+                {
+                    IEnumerable<Diagnostic> failures = result.Diagnostics.Where(d => d.IsWarningAsError || d.Severity == DiagnosticSeverity.Error);
 
-					string errStr = "CS MODS NOT LOADED | Compilation errors:";
-					foreach (Diagnostic diagnostic in failures)
-						errStr += $"\n{diagnostic}";
-					LuaCsSetup.PrintCsError(errStr);
-				}
-				else
-				{
-					mem.Seek(0, SeekOrigin.Begin);
-					Assembly = LoadFromStream(mem);
-				}
-			}
+                    string errStr = "CS MODS NOT LOADED | Compilation errors:";
+                    foreach (Diagnostic diagnostic in failures)
+                        errStr += $"\n{diagnostic}";
+                    LuaCsSetup.PrintCsError(errStr);
+                }
+                else
+                {
+                    mem.Seek(0, SeekOrigin.Begin);
+                    Assembly = LoadFromStream(mem);
+                }
+            }
 
-			if (Assembly != null)
-			{
+            if (Assembly != null)
+            {
                 RegisterAssemblyWithNativeGame(Assembly);
                 try
                 {
@@ -209,11 +209,11 @@ namespace Barotrauma
                     throw re;
                 }
             }
-			else
-			{
-				throw new Exception("Unable to create cs mods assembly.");
-			}
-		}
+            else
+            {
+                throw new Exception("Unable to create cs mods assembly.");
+            }
+        }
 
         /// <summary>
         /// This function should be used whenever a new assembly is created. Wrapper to allow more complicated setup later if need be.
@@ -232,17 +232,17 @@ namespace Barotrauma
             Barotrauma.ReflectionUtils.RemoveAssemblyFromCache(assembly);
         }
 
-		private static string[] DirSearch(string sDir)
-		{
-			if (!Directory.Exists(sDir))
+        private static string[] DirSearch(string sDir)
+        {
+            if (!Directory.Exists(sDir))
             {
-				return new string[] {};
+                return new string[] {};
             }
 
-			return Directory.GetFiles(sDir, "*.cs", SearchOption.AllDirectories);
-		}
+            return Directory.GetFiles(sDir, "*.cs", SearchOption.AllDirectories);
+        }
 
-		public void Clear()
+        public void Clear()
         {
             if (Assembly != null)
             {
@@ -250,5 +250,5 @@ namespace Barotrauma
                 Assembly = null;
             }
         }
-	}
+    }
 }

--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
@@ -186,7 +186,9 @@ namespace Barotrauma
 
                     string errStr = "CS MODS NOT LOADED | Compilation errors:";
                     foreach (Diagnostic diagnostic in failures)
+                    {
                         errStr += $"\n{diagnostic}";
+                    }
                     LuaCsSetup.PrintCsError(errStr);
                 }
                 else

--- a/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/LuaCs/Cs/CsScriptLoader.cs
@@ -14,213 +14,238 @@ using System.Xml.Linq;
 
 namespace Barotrauma
 {
-    class CsScriptLoader : CsScriptBase
-    {
-        private List<MetadataReference> defaultReferences;
+	class CsScriptLoader : CsScriptBase
+	{
+		private List<MetadataReference> defaultReferences;
 
-        private Dictionary<string, List<string>> sources;
-        public Assembly Assembly { get; private set; }
+		private Dictionary<string, List<string>> sources;
+		public Assembly Assembly { get; private set; }
 
-        public CsScriptLoader()
-        {
-            defaultReferences = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(a => !(a.IsDynamic || string.IsNullOrEmpty(a.Location) || a.Location.Contains("xunit")))
-                .Select(a => MetadataReference.CreateFromFile(a.Location) as MetadataReference)
-                .ToList();
+		public CsScriptLoader()
+		{
+			defaultReferences = AppDomain.CurrentDomain.GetAssemblies()
+				.Where(a => !(a.IsDynamic || string.IsNullOrEmpty(a.Location) || a.Location.Contains("xunit")))
+				.Select(a => MetadataReference.CreateFromFile(a.Location) as MetadataReference)
+				.ToList();
 
-            sources = new Dictionary<string, List<string>>();
+			sources = new Dictionary<string, List<string>>();
             Assembly = null;
         }
 
-        private enum RunType { Standard, Forced, None };
-        private bool ShouldRun(ContentPackage cp, string path)
+		private enum RunType { Standard, Forced, None };
+		private bool ShouldRun(ContentPackage cp, string path)
+		{
+			if (!Directory.Exists(path + "CSharp"))
+			{
+				return false;
+			}
+
+			var isEnabled = ContentPackageManager.EnabledPackages.All.Contains(cp);
+			if (File.Exists(path + "CSharp/RunConfig.xml"))
+			{
+				Stream stream = File.Open(path + "CSharp/RunConfig.xml", FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+				var doc = XDocument.Load(stream);
+				var elems = doc.Root.Elements().ToArray();
+				var elem = elems.FirstOrDefault(e => e.Name.LocalName.Equals(LuaCsSetup.IsServer ? "Server" : (LuaCsSetup.IsClient ? "Client" : "None"), StringComparison.OrdinalIgnoreCase));
+
+				if (elem != null && Enum.TryParse(elem.Value, true, out RunType rtValue))
+				{
+					if (rtValue == RunType.Standard && isEnabled)
+					{
+						LuaCsSetup.PrintCsMessage($"Standard run C# of {cp.Name}");
+						return true;
+					}
+					else if (rtValue == RunType.Forced)
+					{
+						LuaCsSetup.PrintCsMessage($"Forced run C# of {cp.Name}");
+						return true;
+					}
+					else if (rtValue == RunType.None)
+					{
+						return false;
+					}
+				}
+
+				stream.Close();
+			}
+
+			if (isEnabled)
+			{
+				LuaCsSetup.PrintCsMessage($"Assumed run C# of {cp.Name}");
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		public void SearchFolders()
+		{
+			var paths = new Dictionary<string, string>();
+			foreach (var cp in ContentPackageManager.AllPackages.Concat(ContentPackageManager.EnabledPackages.All))
+			{
+				var path = $"{Path.GetFullPath(Path.GetDirectoryName(cp.Path)).Replace('\\', '/')}/";
+				if (ShouldRun(cp, path))
+				{
+					if (paths.ContainsKey(cp.Name))
+					{
+						if (ContentPackageManager.EnabledPackages.All.Contains(cp))
+						{
+							paths[cp.Name] = path;
+						}
+					}
+					else
+					{
+						paths.Add(cp.Name, path);
+					}
+				}
+			}
+
+			foreach ((var _, var path) in paths)
+			{
+				RunFolder(path);
+			}
+		}
+
+		public bool HasSources { get => sources.Count > 0; }
+
+		private void AddSources(string folder)
         {
-            if (!Directory.Exists(path + "CSharp"))
-            {
-                return false;
-            }
+			foreach (var str in DirSearch(folder))
+			{
+				string s = str.Replace("\\", "/");
 
-            var isEnabled = ContentPackageManager.EnabledPackages.All.Contains(cp);
-            if (File.Exists(path + "CSharp/RunConfig.xml"))
-            {
-                Stream stream = File.Open(path + "CSharp/RunConfig.xml", FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                var doc = XDocument.Load(stream);
-                var elems = doc.Root.Elements().ToArray();
-                var elem = elems.FirstOrDefault(e => e.Name.LocalName.Equals(LuaCsSetup.IsServer ? "Server" : (LuaCsSetup.IsClient ? "Client" : "None"), StringComparison.OrdinalIgnoreCase));
+				if (sources.ContainsKey(folder))
+				{
+					sources[folder].Add(s);
+				}
+				else
+				{
+					sources.Add(folder, new List<string> { s });
+				}
+			}
+		}
 
-                if (elem != null && Enum.TryParse(elem.Value, true, out RunType rtValue))
-                {
-                    if (rtValue == RunType.Standard && isEnabled)
-                    {
-                        LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Standard)");
-                        return true;
-                    }
-                    else if (rtValue == RunType.Forced)
-                    {
-                        LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Forced)");
-                        return true;
-                    }
-                    else if (rtValue == RunType.None)
-                    {
-                        return false;
-                    }
-                }
+		private void RunFolder(string folder)
+		{
 
-                stream.Close();
-            }
-
-            if (isEnabled)
-            {
-                LuaCsSetup.PrintCsMessage($"Added {cp.Name} {cp.ModVersion} to Cs compilation. (Assumed)");
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        public void SearchFolders()
-        {
-            var packagesAdded = new HashSet<ContentPackage>();
-            var paths = new Dictionary<string, string>();
-            foreach (var cp in ContentPackageManager.AllPackages.Concat(ContentPackageManager.EnabledPackages.All))
-            {
-                if (packagesAdded.Contains(cp)) { continue; }
-
-                var path = $"{Path.GetFullPath(Path.GetDirectoryName(cp.Path)).Replace('\\', '/')}/";
-                if (ShouldRun(cp, path))
-                {
-                    if (paths.ContainsKey(cp.Name))
-                    {
-                        if (ContentPackageManager.EnabledPackages.All.Contains(cp))
-                        {
-                            paths[cp.Name] = path;
-                        }
-                    }
-                    else
-                    {
-                        paths.Add(cp.Name, path);
-                    }
-
-                    packagesAdded.Add(cp);
-                }
-            }
-
-            foreach ((var _, var path) in paths)
-            {
-                RunFolder(path);
-            }
-        }
-
-        public bool HasSources { get => sources.Count > 0; }
-
-        private void AddSources(string folder)
-        {
-            foreach (var str in DirSearch(folder))
-            {
-                string s = str.Replace("\\", "/");
-
-                if (sources.ContainsKey(folder))
-                {
-                    sources[folder].Add(s);
-                }
-                else
-                {
-                    sources.Add(folder, new List<string> { s });
-                }
-            }
-        }
-
-        private void RunFolder(string folder)
-        {
-
-            AddSources(folder + "/CSharp/Shared");
+			AddSources(folder + "/CSharp/Shared");
 
 #if SERVER
-            AddSources(folder + "/CSharp/Server");
+			AddSources(folder + "/CSharp/Server");
 #else
-            AddSources(folder + "/CSharp/Client");
+			AddSources(folder + "/CSharp/Client");
 #endif
-        }
+		}
 
-        private IEnumerable<SyntaxTree> ParseSources() {
-            var syntaxTrees = new List<SyntaxTree>();
+		private IEnumerable<SyntaxTree> ParseSources() {
+			var syntaxTrees = new List<SyntaxTree>();
 
-            if (sources.Count <= 0) throw new Exception("No Cs sources detected");
-            syntaxTrees.Add(AssemblyInfoSyntaxTree(CsScriptAssembly));
-            foreach ((var folder, var src) in sources)
+			if (sources.Count <= 0) throw new Exception("No Cs sources detected");
+			syntaxTrees.Add(AssemblyInfoSyntaxTree(CsScriptAssembly));
+			foreach ((var folder, var src) in sources)
             {
+				try
+				{
+					foreach (var file in src)
+					{
+						var tree = SyntaxFactory.ParseSyntaxTree(File.ReadAllText(file), ParseOptions, file);
+
+						syntaxTrees.Add(tree);
+					}
+				}
+				catch (Exception ex)
+				{
+					LuaCsSetup.PrintCsError("Error loading '" + folder + "':\n" + ex.Message + "\n" + ex.StackTrace);
+				}
+			}
+
+			return syntaxTrees;
+		}
+
+		public List<Type> Compile() 
+		{
+			IEnumerable<SyntaxTree> syntaxTrees = ParseSources();
+
+			var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+				.WithMetadataImportOptions(MetadataImportOptions.All)
+                .WithOptimizationLevel(OptimizationLevel.Release)
+				.WithAllowUnsafe(true); 
+			var compilation = CSharpCompilation.Create(CsScriptAssembly, syntaxTrees, defaultReferences, options);
+
+			using (var mem = new MemoryStream())
+			{
+				var result = compilation.Emit(mem);
+				if (!result.Success)
+				{
+					IEnumerable<Diagnostic> failures = result.Diagnostics.Where(d => d.IsWarningAsError || d.Severity == DiagnosticSeverity.Error);
+
+					string errStr = "CS MODS NOT LOADED | Compilation errors:";
+					foreach (Diagnostic diagnostic in failures)
+						errStr += $"\n{diagnostic}";
+					LuaCsSetup.PrintCsError(errStr);
+				}
+				else
+				{
+					mem.Seek(0, SeekOrigin.Begin);
+					Assembly = LoadFromStream(mem);
+				}
+			}
+
+			if (Assembly != null)
+			{
+                RegisterAssemblyWithNativeGame(Assembly);
                 try
                 {
-                    foreach (var file in src)
-                    {
-                        var tree = SyntaxFactory.ParseSyntaxTree(File.ReadAllText(file), ParseOptions, file);
-
-                        syntaxTrees.Add(tree);
-                    }
+                    return Assembly.GetTypes().Where(t => t.IsSubclassOf(typeof(ACsMod))).ToList();
                 }
-                catch (Exception ex)
+                catch (ReflectionTypeLoadException re)
                 {
-                    LuaCsSetup.PrintCsError("Error loading '" + folder + "':\n" + ex.Message + "\n" + ex.StackTrace);
+                    LuaCsSetup.PrintCsError($"Unable to load CsMod Types. {re.Message}");
+                    throw re;
                 }
             }
+			else
+			{
+				throw new Exception("Unable to create cs mods assembly.");
+			}
+		}
 
-            return syntaxTrees;
+        /// <summary>
+        /// This function should be used whenever a new assembly is created. Wrapper to allow more complicated setup later if need be.
+        /// </summary>
+        private static void RegisterAssemblyWithNativeGame(Assembly assembly)
+        {
+            Barotrauma.ReflectionUtils.AddNonAbstractAssemblyTypes(assembly);
         }
 
-        public List<Type> Compile()
+        /// <summary>
+        /// This function should be used whenever a new assembly is about to be destroyed/unloaded. Wrapper to allow more complicated setup later if need be.
+        /// </summary>
+        /// <param name="assembly">Assembly to remove</param>
+        private static void UnregisterAssemblyFromNativeGame(Assembly assembly)
         {
-            IEnumerable<SyntaxTree> syntaxTrees = ParseSources();
+            Barotrauma.ReflectionUtils.RemoveAssemblyFromCache(assembly);
+        }
 
-            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
-                .WithMetadataImportOptions(MetadataImportOptions.All)
-                .WithOptimizationLevel(OptimizationLevel.Release)
-                .WithAllowUnsafe(false);
-            var compilation = CSharpCompilation.Create(CsScriptAssembly, syntaxTrees, defaultReferences, options);
-
-            using (var mem = new MemoryStream())
+		private static string[] DirSearch(string sDir)
+		{
+			if (!Directory.Exists(sDir))
             {
-                var result = compilation.Emit(mem);
-                if (!result.Success)
-                {
-                    IEnumerable<Diagnostic> failures = result.Diagnostics.Where(d => d.IsWarningAsError || d.Severity == DiagnosticSeverity.Error);
-
-                    string errStr = "CS MODS NOT LOADED | Compilation errors:";
-                    foreach (Diagnostic diagnostic in failures)
-                        errStr += $"\n{diagnostic}";
-                    LuaCsSetup.PrintCsError(errStr);
-                }
-                else
-                {
-                    mem.Seek(0, SeekOrigin.Begin);
-                    Assembly = LoadFromStream(mem);
-                }
+				return new string[] {};
             }
 
+			return Directory.GetFiles(sDir, "*.cs", SearchOption.AllDirectories);
+		}
+
+		public void Clear()
+        {
             if (Assembly != null)
             {
-                return Assembly.GetTypes().Where(t => t.IsSubclassOf(typeof(ACsMod))).ToList();
-            }
-            else
-            {
-                throw new Exception("Unable to create cs mods assembly.");
+                UnregisterAssemblyFromNativeGame(Assembly);
+                Assembly = null;
             }
         }
-
-        private static string[] DirSearch(string sDir)
-        {
-            if (!Directory.Exists(sDir))
-            {
-                return new string[] {};
-            }
-
-            return Directory.GetFiles(sDir, "*.cs", SearchOption.AllDirectories);
-        }
-
-        public void Clear()
-        {
-            Assembly = null;
-        }
-    }
+	}
 }

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
@@ -28,6 +28,11 @@ namespace Barotrauma
             return types;
         }
 
+        /// <summary>
+        /// Adds an assembly's Non-Abstract Types to the cache for Barotrauma's Type lookup. 
+        /// </summary>
+        /// <param name="assembly">Assembly to be added</param>
+        /// <param name="overwrite">Whether or not to overwrite an entry if the assembly already exists within it.</param>
         public static void AddNonAbstractAssemblyTypes(Assembly assembly, bool overwrite = false)
         {
             if (cachedNonAbstractTypes.ContainsKey(assembly))
@@ -52,6 +57,10 @@ namespace Barotrauma
             }
         }
 
+        /// <summary>
+        /// Removes an assembly from the cache for Barotrauma's Type lookup.
+        /// </summary>
+        /// <param name="assembly">Assembly to remove.</param>
         public static void RemoveAssemblyFromCache(Assembly assembly) => cachedNonAbstractTypes.Remove(assembly);
 
         public static Option<TBase> ParseDerived<TBase, TInput>(TInput input) where TInput : notnull

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
@@ -19,6 +19,8 @@ namespace Barotrauma
             if (!cachedNonAbstractTypes.ContainsKey(assembly))
                 AddNonAbstractAssemblyTypes(assembly);
 
+            #warning TODO: Add safety checks in case an assembly is unloaded without being removed from the cache.
+            
             List<Type> types = new List<Type>();
             foreach (var typearr in cachedNonAbstractTypes)
                 types = types.Concat(typearr.Value.Where(t => t.IsSubclassOf(typeof(T)))).ToList();

--- a/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
+++ b/Barotrauma/BarotraumaShared/SharedSource/Utils/ReflectionUtils.cs
@@ -17,13 +17,17 @@ namespace Barotrauma
         {
             Assembly assembly = typeof(T).Assembly;
             if (!cachedNonAbstractTypes.ContainsKey(assembly))
+            {
                 AddNonAbstractAssemblyTypes(assembly);
+            }
 
             #warning TODO: Add safety checks in case an assembly is unloaded without being removed from the cache.
             
             List<Type> types = new List<Type>();
             foreach (var typearr in cachedNonAbstractTypes)
+            {
                 types = types.Concat(typearr.Value.Where(t => t.IsSubclassOf(typeof(T)))).ToList();
+            }
             
             return types;
         }


### PR DESCRIPTION
Adds support and automatic management for mod class types to be added to the native Barotrauma Reflection Type lookup. This allows mods to create completely new Item & ItemComponent subtypes and implement completely new types of functionality into the base game.

Notes: This PR replaces the previous one and is rebased against the `develop` branch.